### PR TITLE
Removed the so called "old stuff" that prevented compilation

### DIFF
--- a/source/mstd/src/lib.rs
+++ b/source/mstd/src/lib.rs
@@ -13,12 +13,6 @@ extern "Rust" {
     fn entry() -> !;
 }
 
-#[link_section = ".anachro_table.entry_point"]
-#[no_mangle]
-#[used]
-#[doc(hidden)]
-pub static __ENTRY_POINT: unsafe fn() -> ! = entry;
-
 // Provide a basic panic handler. In the future, this will probably
 // change to one or both of:
 //


### PR DESCRIPTION
Removed that "old stuff" that can cause compile errors

https://github.com/tosc-rs/mnemos/blob/ead2f185560d08f299336541e62e07b6e59b5639/source/mstd/src/lib.rs#L16-L20